### PR TITLE
Add llms.txt, No-Vary-Search UTM dedup, and richer structured data

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -6,6 +6,7 @@
 
 /*
   Cache-Control: public, max-age=3600, must-revalidate
+  No-Vary-Search: key-order, params=("utm_source" "utm_medium" "utm_campaign" "utm_content" "utm_term")
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   X-Frame-Options: DENY

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Allow: /
-
-Sitemap: https://saf1.me/sitemap-index.xml

--- a/src/components/BackButton.astro
+++ b/src/components/BackButton.astro
@@ -23,11 +23,13 @@ const { href } = Astro.props
 </Button>
 
 <script>
-	document.querySelector<HTMLAnchorElement>('[data-back-fallback]')?.addEventListener('click', (e) => {
-		const ref = document.referrer
-		if (ref && new URL(ref).origin === location.origin) {
-			e.preventDefault()
-			history.back()
-		}
-	})
+	document
+		.querySelector<HTMLAnchorElement>('[data-back-fallback]')
+		?.addEventListener('click', (e) => {
+			const ref = document.referrer
+			if (ref && new URL(ref).origin === location.origin) {
+				e.preventDefault()
+				history.back()
+			}
+		})
 </script>

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -51,7 +51,13 @@ const ogHeight = defaultCard ? defaultCard.height : ogImageHeight
 <link rel='preload' href='/fonts/Satoshi-Variable.woff2' as='font' type='font/woff2' crossorigin />
 
 {/* Robots */}
-{noIndex && <meta content='noindex, nofollow' name='robots' />}
+{
+	noIndex ? (
+		<meta content='noindex, nofollow' name='robots' />
+	) : (
+		<meta content='max-snippet:-1, max-image-preview:large, max-video-preview:-1' name='robots' />
+	)
+}
 
 {/* Canonical URL */}
 {!noIndex && <link rel='canonical' href={canonicalURL} />}
@@ -94,6 +100,15 @@ const ogHeight = defaultCard ? defaultCard.height : ogImageHeight
 
 {/* Sitemap */}
 <link href='/sitemap-index.xml' rel='sitemap' />
+
+{
+	/* AI/agent discovery — /llms.txt covers this; a separate schemamap.xml was removed
+     because it duplicated sitemap-index.xml with no structural difference. If richer
+     per-post metadata (title, tags, reading time) is ever needed for AI crawlers,
+     a JSON entity map would be the right form, not another <urlset> clone. */
+}
+{/* rel='llms-txt' is non-standard (emerging llms.txt spec) — browsers ignore unknown rel values */}
+<link href='/llms.txt' rel='llms-txt' />
 
 {/* RSS auto-discovery */}
 <link href='/rss.xml' rel='alternate' title={siteConfig.title} type='application/rss+xml' />

--- a/src/content/post/legacy-api-security/index.md
+++ b/src/content/post/legacy-api-security/index.md
@@ -16,7 +16,7 @@ That single constraint changes everything. You are not securing a system. You ar
 >
 > - When client apps cannot be updated, the API response shape becomes a frozen contract. Security fixes have to preserve every key, type, and status code the old clients expect.
 > - The cheapest, most dangerous flaws are usually trust ones: the server believing whatever the client says about payment, auth, or identity.
-> - Shadow mode and feature flags let you enforce new checks gradually. You log what a fix *would* have blocked before you let it block anything for real.
+> - Shadow mode and feature flags let you enforce new checks gradually. You log what a fix _would_ have blocked before you let it block anything for real.
 
 ## What I was handed
 
@@ -28,7 +28,7 @@ It worked. It also felt like an MVP that sprinted past the prototype stage and n
 
 I found nine issues. The pattern underneath most of them is the same: the server trusts the client.
 
-The payment check was the clearest example. The API let the app *tell it* whether the user had paid. Flip a boolean on the device and you unlock everything for free. The server never verified anything.
+The payment check was the clearest example. The API let the app _tell it_ whether the user had paid. Flip a boolean on the device and you unlock everything for free. The server never verified anything.
 
 Auth was no better. One endpoint accepted the literal string `1234` as a valid token and waved the request through. The admin login only checked the password in client-side JavaScript, so the actual server endpoints sat wide open behind a cosmetic gate. Several route-management endpoints checked for no token at all, which meant anyone could delete data.
 

--- a/src/content/post/linux-font-rendering/index.md
+++ b/src/content/post/linux-font-rendering/index.md
@@ -15,7 +15,7 @@ period: learning new shortcuts, finding equivalent apps, tweaking the desktop. W
 I didn't expect was to spend hours staring at my screen wondering why the text
 looked so wrong.
 
-Not broken, just *off*. Fuzzy at small sizes. Thin in places that felt wrong. Weirdly
+Not broken, just _off_. Fuzzy at small sizes. Thin in places that felt wrong. Weirdly
 light on a dark background. On a 1080p IPS monitor like the BenQ GW2480, it was
 impossible to ignore. Windows fonts had always felt sharp and weighted just right.
 Linux felt like reading through frosted glass.
@@ -90,7 +90,7 @@ taken by the **lucidglyph** project.
 
 The project is maintained by **maximilionus** on GitHub:
 [github.com/maximilionus/lucidglyph](https://github.com/maximilionus/lucidglyph).
-Previously known as *freetype-envision*, it is a carefully curated collection of
+Previously known as _freetype-envision_, it is a carefully curated collection of
 FreeType and Fontconfig tweaks that together replicate the macOS-style stem-darkening
 approach on Linux.
 

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,44 @@
+import { getAllPosts, sortMDByDate } from '@/utils'
+import { siteConfig } from '@/site-config'
+
+export const prerender = true
+
+export async function GET() {
+	const posts = await getAllPosts()
+	const latestPosts = sortMDByDate(posts).slice(0, 10)
+
+	const lines = [
+		`# ${siteConfig.title}`,
+		'',
+		`> ${siteConfig.description}`,
+		'',
+		`Website: ${siteConfig.url}`,
+		...(latestPosts.length > 0
+			? [
+					'',
+					'## Recent posts',
+					...latestPosts.map((post) => {
+						const title = post.data.title
+							.replace(/\[/g, '\\[')
+							.replace(/\]/g, '\\]')
+							.replace(/\(/g, '\\(')
+							.replace(/\)/g, '\\)')
+							.replace(/`/g, '\\`')
+							.replace(/\*/g, '\\*')
+						return `- [${title}](${new URL(`/blog/${post.id}/`, siteConfig.url).href})`
+					})
+				]
+			: []),
+		'',
+		'## Resources',
+		`- Blog: ${new URL('/blog/', siteConfig.url).href}`,
+		`- About: ${new URL('/about/', siteConfig.url).href}`,
+		`- RSS: ${new URL('/rss.xml', siteConfig.url).href}`
+	]
+
+	return new Response(lines.join('\n') + '\n', {
+		headers: {
+			'Content-Type': 'text/plain; charset=utf-8'
+		}
+	})
+}

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,17 @@
+import { siteConfig } from '@/site-config'
+
+export const prerender = true
+
+export async function GET() {
+	const content =
+		[
+			'User-agent: *',
+			'Allow: /',
+			'',
+			`Sitemap: ${new URL('/sitemap-index.xml', siteConfig.url).href}`
+		].join('\n') + '\n'
+
+	return new Response(content, {
+		headers: { 'Content-Type': 'text/plain; charset=utf-8' }
+	})
+}

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -28,6 +28,7 @@ export const personSchema = {
 	jobTitle: 'Software Developer',
 	description: siteConfig.bio,
 	knowsAbout: ['Software Development', 'KDE', 'Linux', 'Web Development', 'Databases', 'DevOps'],
+	publishingPrinciples: `${ORIGIN}/about/`,
 	address: {
 		'@type': 'PostalAddress',
 		addressCountry: 'Bangladesh'
@@ -40,5 +41,7 @@ export const websiteSchema = {
 	'@type': 'WebSite',
 	name: siteConfig.author,
 	url: ORIGIN,
-	publisher: { '@id': PERSON_ID }
+	publisher: { '@id': PERSON_ID },
+	copyrightHolder: { '@id': PERSON_ID },
+	copyrightYear: new Date().getFullYear()
 }


### PR DESCRIPTION
## Summary

- Add `/llms.txt` generated endpoint (10 latest posts, markdown-escaped titles) with `<link rel='llms-txt'>` discovery in `<head>` for AI crawler compatibility
- Migrate `robots.txt` from static `public/` to a generated page that derives the sitemap URL from `siteConfig`
- Add `No-Vary-Search` header to deduplicate UTM-variant cache entries across all routes
- Emit explicit `robots` meta on indexable pages (`max-snippet:-1` etc.); suppress canonical when `noIndex` is true
- Enrich JSON-LD: `publishingPrinciples` on Person schema, `copyrightHolder` + `copyrightYear` on WebSite schema
- Prettier normalizations: BackButton script reformat, `*emphasis*` → `_emphasis_` in two posts

## Test plan

- [ ] `/llms.txt` returns valid plain-text with post links
- [ ] `/robots.txt` returns correct `User-agent` + `Sitemap` referencing siteConfig URL
- [ ] All pages have correct `<link rel='canonical'>` (absent on noIndex pages)
- [ ] No-Vary-Search header present in response for `/*` routes
- [ ] Build passes (`npm run build`)